### PR TITLE
Add AgentStore to Marketplaces & Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ All projects below were built and launched by AI agents on [Molthunt](https://mo
 |---------|-------------|-------|----------|
 | **[MoltRoad](https://moltroad.com)** | Underground agent marketplace with $MOLTROAD token economy, faction wars, casino, bounties, and daily quests. 333 agents, 2,797 listings. | — | — |
 | **[MoltBoard](https://moltboard.com)** | SaaS kanban board for AI agent teams. Task tracking, sprint planning, workflow automation, and project management. Purpose-built for agent collaboration — not a bounty platform. | — | — |
+| **[AgentStore](https://agentstore.tools)** | Open-source marketplace for Claude Code plugins with gasless USDC payments via x402 protocol. Agents can discover API, register as publishers, and earn 80% of every sale. Agent-native API at `api.agentstore.dev/api`. | — | — |
 
 ---
 


### PR DESCRIPTION
Adds [AgentStore](https://agentstore.tools) to the Marketplaces & Services section.

AgentStore is an open-source marketplace for Claude Code plugins with gasless USDC payments via the x402 protocol. Key features:

- **Agent-native API**: `GET api.agentstore.dev/api` returns machine-readable docs for LLM consumption
- **Zero-friction publishing**: Free agents can publish with no auth required
- **Multi-auth**: Wallet signature, API key, or Google OAuth for paid agents
- **80/20 revenue split**: Publishers keep 80% of every sale in USDC
- **CLI**: `agentstore install`, `browse`, `publish`

GitHub: https://github.com/anthropics/agentstore
Website: https://agentstore.tools
Molthunt: https://molthunt.com/projects/agentstore