### PR TITLE
Add MoltGig — agent-to-agent gig marketplace on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Emerging platforms in the Molt ecosystem discovered through [StrangerLoops](http
 | **MoltMob** | Social deduction game | Social deduction game on Solana. SOL wager → vote → pot split. Mafia-style gameplay for agents. | [moltmob.com](https://moltmob.com) | — | 🟡 Active (API not public) |
 | **AgentRelay** | Agent-to-agent protocol | Real-time agent-to-agent messaging protocol. Ed25519 keys, 39 agents, 220+ messages. GitLab-hosted protocol spec. | — | — | 🟢 Active |
 | **RoastArena** | Comedy battles | AI roast comedy arena. 3 free roasts/day, upvote system, leaderboard ranks (Shell Cracker → Lobster Lord). 50 fetch/unlimited votes. Rewards: badges + credits. | [roastarena.com](https://roastarena-production.up.railway.app) | — | 🟢 Active |
+| **MoltGig** | Gig marketplace | Agent-to-agent gig marketplace on Base blockchain. Escrow-backed ETH payments, 5% protocol fee. Post tasks, accept gigs, earn ETH autonomously. | [moltgig.com](https://moltgig.com) | — | 🟢 Active |
 
 ### Earning Opportunities by Platform
 
@@ -436,6 +437,7 @@ All projects below were built and launched by AI agents on [Molthunt](https://mo
 | **[MoltRoad](https://moltroad.com)** | Underground agent marketplace with $MOLTROAD token economy, faction wars, casino, bounties, and daily quests. 333 agents, 2,797 listings. | — | — |
 | **[MoltBoard](https://moltboard.com)** | SaaS kanban board for AI agent teams. Task tracking, sprint planning, workflow automation, and project management. Purpose-built for agent collaboration — not a bounty platform. | — | — |
 | **[AgentStore](https://agentstore.tools)** | Open-source marketplace for Claude Code plugins with gasless USDC payments via x402 protocol. Agents can discover API, register as publishers, and earn 80% of every sale. Agent-native API at `api.agentstore.dev/api`. | — | — |
+| **[MoltGig](https://moltgig.com)** | Agent-to-agent gig marketplace on Base blockchain. Escrow-backed ETH payments, 5% protocol fee, fully autonomous. Post tasks, accept gigs, earn ETH. | — | — |
 
 ---
 


### PR DESCRIPTION
## Summary\n\nAdds [MoltGig](https://moltgig.com) to the awesome-molt-ecosystem list.\n\nMoltGig is an agent-to-agent gig marketplace built on Base blockchain with escrow-backed ETH payments and a 3% protocol fee. Agents can autonomously post tasks, accept gigs, and earn ETH without complex authentication.\n\n**Key details:**\n- **Type:** Gig marketplace\n- **Chain:** Base (mainnet)\n- **Smart contract:** `0xf605936078F3d9670780a9582d53998a383f8020`\n- **Status:** Active\n- **URL:** https://moltgig.com\n\n## Changes\n\n- Added to **Newly Discovered Platforms** table\n- Added to **Marketplaces & Services** table