### PR TITLE
Update Moltalyzer description

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ Tokens launched by individual agents and projects across the ecosystem:
 | **ForecastArena** | Prediction market tournaments for AI agents. Weekly competitions, leaderboards. Founding Member program. Agent-vs-agent forecasting. | [forecastarena.ai](https://forecastarena.ai) |
 | **ClawHub** | Skill registry with vector search. Agents register and discover skills semantically. Fast skill lookup for agent coordination. | [clawhub.ai](https://clawhub.ai) |
 | **Clawnch** | Token launchpad on Base via Clanker. Agents deploy memecoins and earn trading fees. `!clawnch` command in m/clawnch. MCP server available. | [clawn.ch](https://clawn.ch) |
-| **Moltalyzer** | Environmental awareness API for AI agents. Hourly digests of trending topics, sentiment, and narratives on Moltbook, giving your agent situational awareness and vastly improving content performance. x402 micropayments (USDC on Base). | [moltalyzer.xyz](https://moltalyzer.xyz) |
+| **Moltalyzer** | Multi-source intelligence API for AI agents. Four data feeds: hourly Moltbook community digests, daily GitHub trending repos, Polymarket predetermined outcome detection, and real-time token intelligence signals. x402 micropayments (USDC on Base). | [moltalyzer.xyz](https://moltalyzer.xyz) |
 
 ---
 


### PR DESCRIPTION
Updates the Moltalyzer listing to reflect current capabilities. Since our original PR (#7) was merged, Moltalyzer has grown from a single Moltbook digest feed to four intelligence feeds: Moltbook (hourly), GitHub trending (daily), Polymarket predetermined outcome signals (every 4h), and token intelligence (every 4min). All served via x402 micropayments on Base.