### PR TITLE
Add TensorFeed to Tier A x402 services

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Working APIs, real payment rails, but insufficient task volume or liquidity.
 | **MCP-Hive** 🆕 | [mcp-hive.com](https://mcp-hive.com) | Per-invocation | Pre-launch | REG済, Founding Provider (0% fee!), launches 5/11 |
 | **MonetizeYourAgent** 🆕 | [monetizeyouragent.fun](https://monetizeyouragent.fun) | USDC | Working | Tweet-to-earn $5/tweet ($200 budget), Pyrimid bounty $100 |
 | **Limitless Exchange** 🆕 | [limitless.exchange](https://limitless.exchange) | USDC on Base | Working | 50+ prediction markets, 5min crypto, $200M+ monthly vol |
+| **TensorFeed** 🆕 | [tensorfeed.ai](https://tensorfeed.ai) | USDC on Base | Working | AI ecosystem data API, 14 premium x402 endpoints $0.02/call, AFTA-certified, MCP server (42 tools) |
 
 ---
 


### PR DESCRIPTION
## What

Adds [TensorFeed](https://tensorfeed.ai) to the **Tier A: Real Infrastructure** table.

## TensorFeed in one paragraph

Real-time AI ecosystem data API. Free tier covers AI news from 50+ sources, model pricing across major labs, AI service status (Claude, OpenAI, Gemini, Grok, etc), MCP registry growth, GitHub trending, AI papers (arXiv + Semantic Scholar + HF Daily), AI hardware, GPU pricing, plus economy and policy feeds. 14 premium pay-per-call endpoints (routing recommendations, multi-day history series, news search, cost projection, model comparison, provider deep-dives, recession watch, MCP registry growth series) priced in USDC on Base via the x402 protocol. $0.02/call at base rate, volume bundles down to $0.012.

Wallet (Base): `0x549c82e6bfc54bdae9a2073744cbc2af5d1fc6d1`

## Why this fits Tier A

Working API, real x402 payment rail (USDC on Base mainnet), public deployment since April 2026. End-to-end USDC loop verified on Base mainnet 2026-04-27. Python and TypeScript SDKs published. MCP server (`@tensorfeed/mcp-server`, 42 tools) listed in the official MCP Registry as `ai.tensorfeed/mcp-server`.

## AFTA

Covered by the [Agent Fair-Trade Agreement](https://tensorfeed.ai/agent-fair-trade) (an open standard for fair-trade agent APIs): code-enforced no-charge guarantees on 5xx, circuit breaker, schema validation failure, or stale data. Every paid call returns an Ed25519-signed receipt verifiable at `/api/receipt/verify`.

## Verification

- Repo: https://github.com/RipperMercs/tensorfeed (public)
- Free endpoint: `curl https://tensorfeed.ai/api/news` returns JSON immediately, no auth.
- Premium 402 challenge: `curl -i https://tensorfeed.ai/api/premium/routing` returns canonical x402 v1 response with X-Payment-* headers.
- Standard manifest: https://tensorfeed.ai/.well-known/agent-fair-trade.json
- AFTA federation: paired with [TerminalFeed.io](https://terminalfeed.io)