### PR TITLE
feat: add TWZRD Agent Intel — Solana x402 trust scoring layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,20 @@ HTTP 402 Payment Required. The standard that won the agent payment wars.
 
 **Total x402 revenue: $0.27** — discovery ≠ buyers. Owning the rails is the floor, not the ceiling.
 
+### Trust Layer for x402 Payments
+
+Before making an x402 micropayment to an agent, verify it's who it claims to be:
+
+| Service | URL | What It Does | Protocol | Price |
+|---------|-----|-------------|----------|-------|
+| **TWZRD Agent Intel** | [intel.twzrd.xyz](https://intel.twzrd.xyz) | Trust score + on-chain identity verification for Solana agent wallets | MCP over HTTP | Free (score) / $0.002 USDC (signed receipt) |
+
+**Use case:** Call `score_agent(wallet)` before paying an unfamiliar agent. Call `get_trust_receipt(wallet)` for a signed on-chain provenance receipt usable as an x402 preflight check.
+
+**MCP config:** `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
+
+Official MCP Registry: `xyz.twzrd.intel/twzrd-agent-intel` (active, v1.0.2)
+
 ### x402 Ecosystem Update (April 2026)
 
 - **Agentic.market** launched 4/21 — Coinbase's official x402 app store. 523 services, 69K agents, permissionless listing


### PR DESCRIPTION
## Summary

Adds TWZRD Agent Intel as a trust layer entry in the **x402 Economy** section — specifically as infrastructure for verifying agent identity before making x402 micropayments.

**Why it fits here:**
- TWZRD Agent Intel is an MCP server for Solana that provides free wallet trust scoring + paid signed on-chain trust receipts (x402 micropayment)
- It addresses the "who are you paying?" problem in agent-to-agent x402 transactions
- Already in the official MCP Registry as `xyz.twzrd.intel/twzrd-agent-intel` (active, v1.0.2)
- Free preflight: `score_agent(wallet)` — no USDC needed
- Paid receipt: `get_trust_receipt(wallet)` — $0.002 USDC via x402

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

This is relevant to your Rounds 47-49 work on self-hosted x402 endpoints — before other agents pay your endpoints, they'd want to verify trust. Similarly, when your agents call external x402 services, they can preflight with TWZRD to score the recipient wallet.
