### PR TITLE
feat: add The Stall — 210 pay-per-call AI capabilities via x402 (MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ Working APIs, real payment rails, but insufficient task volume or liquidity.
 | **MonetizeYourAgent** 🆕 | [monetizeyouragent.fun](https://monetizeyouragent.fun) | USDC | Working | Tweet-to-earn $5/tweet ($200 budget), Pyrimid bounty $100 |
 | **Limitless Exchange** 🆕 | [limitless.exchange](https://limitless.exchange) | USDC on Base | Working | 50+ prediction markets, 5min crypto, $200M+ monthly vol |
 | **TensorFeed** 🆕 | [tensorfeed.ai](https://tensorfeed.ai) | USDC on Base | Working | AI ecosystem data API, 14 premium x402 endpoints $0.02/call, AFTA-certified, MCP server (42 tools) |
+| **The Stall** 🆕 | [the-stall.intuitek.ai/mcp](https://the-stall.intuitek.ai/mcp) | USDC on Base x402 | Working | 181-tool MCP server, pay-per-call x402 micropayments, blockchain OSINT, OFAC screening, DeFi analytics, finance data |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Working APIs, real payment rails, but insufficient task volume or liquidity.
 | **MonetizeYourAgent** 🆕 | [monetizeyouragent.fun](https://monetizeyouragent.fun) | USDC | Working | Tweet-to-earn $5/tweet ($200 budget), Pyrimid bounty $100 |
 | **Limitless Exchange** 🆕 | [limitless.exchange](https://limitless.exchange) | USDC on Base | Working | 50+ prediction markets, 5min crypto, $200M+ monthly vol |
 | **TensorFeed** 🆕 | [tensorfeed.ai](https://tensorfeed.ai) | USDC on Base | Working | AI ecosystem data API, 14 premium x402 endpoints $0.02/call, AFTA-certified, MCP server (42 tools) |
-| **The Stall** 🆕 | [the-stall.intuitek.ai/mcp](https://the-stall.intuitek.ai/mcp) | USDC on Base x402 | Working | 181-tool MCP server, pay-per-call x402 micropayments, blockchain OSINT, OFAC screening, DeFi analytics, finance data |
+| **The Stall** 🆕 | [the-stall.intuitek.ai/mcp](https://the-stall.intuitek.ai/mcp) | USDC on Base x402 | Working | 183-tool MCP server, pay-per-call x402 micropayments, blockchain OSINT, OFAC screening, DeFi analytics, finance data |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Working APIs, real payment rails, but insufficient task volume or liquidity.
 | **MonetizeYourAgent** 🆕 | [monetizeyouragent.fun](https://monetizeyouragent.fun) | USDC | Working | Tweet-to-earn $5/tweet ($200 budget), Pyrimid bounty $100 |
 | **Limitless Exchange** 🆕 | [limitless.exchange](https://limitless.exchange) | USDC on Base | Working | 50+ prediction markets, 5min crypto, $200M+ monthly vol |
 | **TensorFeed** 🆕 | [tensorfeed.ai](https://tensorfeed.ai) | USDC on Base | Working | AI ecosystem data API, 14 premium x402 endpoints $0.02/call, AFTA-certified, MCP server (42 tools) |
-| **The Stall** 🆕 | [the-stall.intuitek.ai/mcp](https://the-stall.intuitek.ai/mcp) | USDC on Base x402 | Working | 183-tool MCP server, pay-per-call x402 micropayments, blockchain OSINT, OFAC screening, DeFi analytics, finance data |
+| **The Stall** 🆕 | [the-stall.intuitek.ai/mcp](https://the-stall.intuitek.ai/mcp) | USDC on Base x402 | Working | 207-tool MCP server, pay-per-call x402 micropayments, blockchain OSINT, OFAC screening, DeFi analytics, finance data |
 
 ---
 


### PR DESCRIPTION
## Adding The Stall to Tier A

Adds **The Stall** to the *Tier A: Real Infrastructure, Waiting for Users* section — it matches the TensorFeed entry pattern (MCP server + x402 + USDC on Base).

**The Stall**
- **209-capability** remote MCP server (v4.63.1)
- Pay-per-call via x402 HTTP 402 micropayments (USDC on Base)
- Covers: blockchain OSINT, OFAC screening, DeFi analytics, equity data, crypto intel, options, macro data, AI synthesis
- Live at: https://the-stall.intuitek.ai
- No API keys required for agents to call (all upstream sources are free/public)
- $1.151 USDC earned on-chain (confirmed via Blockscout 0x03d773...)
- First organic payer confirmed 2026-06-09T19:51Z

Fits Tier A: the infrastructure works end-to-end, rails verified, waiting for organic demand at scale.
