### PR TITLE
Add AgentCourt - x402 dispute resolution infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,20 @@ HTTP 402 Payment Required. The standard that won the agent payment wars.
 | SDK | `@anthropic-ai/x402` | npm |
 | Bazaar (Discovery) | Coinbase CDP | Auto-registers on first tx |
 | Gateway | Pay Gate (pay-skill.com) | Reverse proxy, any API |
+| Dispute Resolution | AgentCourt | Production, 7 policies, $0.05/dispute |
+
+### Dispute Resolution (AgentCourt)
+
+| | |
+|---|---|
+| **URL** | [agentcourt-api-production.up.railway.app](https://agentcourt-api-production.up.railway.app/docs) |
+| **What** | Policy-driven dispute resolution API for agent commerce |
+| **Earning** | $0.05/dispute (USDC on Base), free tier: 100/mo |
+| **Auth** | None (free tier), x402 for paid |
+| **Status** | Production, 7 policies, 39 rules, <500ms rulings |
+| **GitHub** | [vbkotecha/agentcourt-api](https://github.com/vbkotecha/agentcourt-api) |
+| **x402** | Native, manifest at `/.well-known/x402` |
+
 
 ### Our x402 Deployments
 


### PR DESCRIPTION
## AgentCourt — Dispute Resolution for x402 Agent Commerce

Added to the x402 Economy Infrastructure section.

**What:** Policy-driven dispute resolution API. When agents transact via x402 and things go wrong (schema mismatch, non-delivery, SLA breach), AgentCourt evaluates evidence and returns a deterministic ruling in <500ms.

| Field | Value |
|-------|-------|
| URL | https://agentcourt-api-production.up.railway.app/docs |
| Earning | $0.05/dispute (USDC on Base), free tier: 100/mo |
| Auth | None (free), x402 for paid |
| Status | Production, 7 policies, 39 rules |
| GitHub | https://github.com/vbkotecha/agentcourt-api |
| x402 | Native, manifest at /.well-known/x402 |

**Why this matters:** Dispute resolution is a missing primitive in x402. Agents can pay (x402), discover (CDP Bazaar), and communicate (A2A). But when a transaction goes wrong, there's no resolution layer. AgentCourt fills that gap.