### PR TITLE
Update AgentCourt to AgentServices — rebranded to x402 data API platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,19 +611,21 @@ HTTP 402 Payment Required. The standard that won the agent payment wars.
 | SDK | `@anthropic-ai/x402` | npm |
 | Bazaar (Discovery) | Coinbase CDP | Auto-registers on first tx |
 | Gateway | Pay Gate (pay-skill.com) | Reverse proxy, any API |
-| Dispute Resolution | AgentCourt | Production, 7 policies, $0.05/dispute |
+| Data APIs & Intelligence | AgentServices | Production, 54 services, x402-paid |
 
-### Dispute Resolution (AgentCourt)
+### Data APIs & Intelligence (AgentServices)
 
 | | |
 |---|---|
-| **URL** | [agentcourt-api-production.up.railway.app](https://agentcourt-api-production.up.railway.app/docs) |
-| **What** | Policy-driven dispute resolution API for agent commerce |
-| **Earning** | $0.05/dispute (USDC on Base), free tier: 100/mo |
-| **Auth** | None (free tier), x402 for paid |
-| **Status** | Production, 7 policies, 39 rules, <500ms rulings |
-| **GitHub** | [vbkotecha/agentcourt-api](https://github.com/vbkotecha/agentcourt-api) |
-| **x402** | Native, manifest at `/.well-known/x402` |
+| **URL** | [agentservices.to](https://agentservices.to) |
+| **API** | [api.agentservices.to](https://api.agentservices.to) |
+| **What** | x402-paid financial data APIs for AI agents: forex, crypto, stocks, SEC filings, news, market intelligence |
+| **Earning** | $0.001-$0.05/call (USDC on Base via x402) |
+| **Auth** | x402 payment (no API keys needed) |
+| **Status** | Production, 54 services, 97 API paths, 37 MCP tools |
+| **GitHub** | [vbkotecha/aiservices-api](https://github.com/vbkotecha/aiservices-api) |
+| **MCP** | Native, 37 tools (finance, analytics, crypto, security, SEO) |
+| **x402** | Native, manifest at `/.well-known/x402` (35 resources) |
 
 
 ### Our x402 Deployments


### PR DESCRIPTION
## What

Updated the AgentCourt section to reflect the rebrand to **AgentServices** — a x402-paid financial data API platform for AI agents.

## Changes

- **Table entry**: "Dispute Resolution | AgentCourt" → "Data APIs & Intelligence | AgentServices"
- **Section header**: "Dispute Resolution (AgentCourt)" → "Data APIs & Intelligence (AgentServices)"
- **URL**: Updated from dead agentcourt-api-production.up.railway.app to live agentservices.to
- **What**: Updated from dispute resolution to financial data APIs (forex, crypto, stocks, SEC filings, news)
- **Status**: Updated to current production stats: 54 services, 97 API paths, 37 MCP tools
- **GitHub**: Updated to current repo (aiservices-api)

## Why

AgentCourt was the original product name. It has been rebranded to AgentServices with a much broader scope — x402-paid financial data APIs for AI agents. The old URL (agentcourt-api-production.up.railway.app) is dead. The new endpoints are live at agentservices.to and api.agentservices.to.

**Live verification:**
- Homepage: https://agentservices.to (200 OK)
- API: https://api.agentservices.to (200 OK, v5.3.0)
- MCP: 37 tools, protocol 2026-07-28
- x402: 35 resources at /.well-known/x402, USDC on Base